### PR TITLE
fix exports and injection parsing

### DIFF
--- a/globstar/src/context.rs
+++ b/globstar/src/context.rs
@@ -10,8 +10,12 @@ pub struct Context<'a> {
     pub(crate) injected_trees: Vec<InjectedTree>,
 }
 
+/// The injected tree
 pub struct InjectedTree {
+    /// The newly parsed tree
     pub tree: Tree,
+
+    /// The range spanned by the tree
     pub original_range: Range,
 }
 

--- a/globstar/src/lib.rs
+++ b/globstar/src/lib.rs
@@ -17,7 +17,7 @@ mod test_utils;
 
 use std::fmt;
 
-use context::{Context, InjectedTree};
+pub use context::{Context, InjectedTree};
 use err::InjectionErr;
 use scope_resolution::ResolutionMethod;
 use tree_sitter::{Language, Node, Parser, Query, QueryCursor, QueryError, Range};
@@ -87,8 +87,12 @@ impl Injection {
     /// Note: `query` is a tree-sitter query in the outer language, `language`
     /// is the nested language, which is then used to parse the result of the
     /// query.
-    pub fn new(query: &str, language: Language) -> Result<Self, InjectionErr> {
-        let query = Query::new(language, query).map_err(InjectionErr::Query)?;
+    pub fn new(
+        query: &str,
+        source_language: Language,
+        target_language: Language,
+    ) -> Result<Self, InjectionErr> {
+        let query = Query::new(source_language, query).map_err(InjectionErr::Query)?;
         if !query
             .capture_names()
             .iter()
@@ -96,7 +100,10 @@ impl Injection {
         {
             Err(InjectionErr::MissingCapture)
         } else {
-            Ok(Self { query, language })
+            Ok(Self {
+                query,
+                language: target_language,
+            })
         }
     }
 }
@@ -264,7 +271,6 @@ pub type ValidatorFn = for<'a> fn(Node, &Option<Context<'a>>, &[u8]) -> Vec<Occu
 ///
 /// Example: TODO
 #[derive(Copy, Clone, Debug)]
-#[non_exhaustive]
 pub struct Lint {
     /// The name of this lint, for e.g.: `UNUSED_VARIABLES`
     pub name: &'static str,

--- a/globstar/src/test_utils.rs
+++ b/globstar/src/test_utils.rs
@@ -3,13 +3,13 @@ use crate::Linter;
 impl Linter {
     /// Test the linter on an annotated source file
     pub fn test(&self, src: &str) {
-        use crate::{Diagnostic, Occurrence};
+        use crate::Occurrence;
 
         use pretty_assertions::assert_eq as pretty_assert_eq;
         use test_utils::{extract_annotations, trim_indent};
 
         let src = trim_indent(src);
-        let annotations = extract_annotations(&src, self.comment_str);
+        let annotations = extract_annotations(&src, self.comment_str.as_str());
         let occurrences = self.__analyze(&src);
 
         // panic if there are more annotations than diagnostics produced
@@ -31,10 +31,7 @@ impl Linter {
 
         for (annotation, occurrence) in annotations.iter().zip(occurrences) {
             let ((range, content), comment) = annotation;
-            let Occurrence {
-                diagnostic: Diagnostic { at, message },
-                ..
-            } = occurrence;
+            let Occurrence { at, message, .. } = occurrence;
 
             let actual_content = &src[at.start_byte..at.end_byte];
 


### PR DESCRIPTION
- unfortunately, src/test_utils.rs does not get checked by cargo check because it is provided under a feature flag. note to self: use cargo check --all-features in CI, when CI is in place.
- injections were being parsed in the wrong language
- certain exports were made private accidentally