### PR TITLE
add examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,27 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -34,9 +25,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
  "syn",
@@ -44,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "globstar"
@@ -54,6 +45,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "marvin",
+ "once_cell",
  "pretty_assertions",
  "regex",
  "scope-resolution",
@@ -61,15 +53,18 @@ dependencies = [
  "thiserror",
  "tree-sitter",
  "tree-sitter-bash",
+ "tree-sitter-dockerfile",
+ "tree-sitter-elm",
  "tree-sitter-ruby",
+ "tree-sitter-rust",
  "tree-sitter-yaml",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "lazy_static"
@@ -79,9 +74,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -98,54 +93,60 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "once_cell"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "output_vt100"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "pretty_assertions"
-version = "1.0.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
 dependencies = [
- "ansi_term",
  "ctor",
  "diff",
  "output_vt100",
+ "yansi",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -154,15 +155,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "scope-resolution"
@@ -173,18 +174,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -193,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -204,13 +205,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -219,18 +220,18 @@ version = "0.1.0"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -256,9 +257,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dockerfile"
+version = "0.1.0"
+source = "git+https://github.com/akshay-deepsource/tree-sitter-dockerfile#f08a3a4678378939516b5283d0dbdb2c7c16e426"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-elm"
+version = "5.6.3"
+source = "git+https://github.com/akshay-deepsource/tree-sitter-elm#bc17bf040c618c5697eb0298b7910f334a6e1727"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-ruby"
 version = "0.19.0"
 source = "git+https://github.com/akshay-deepsource/tree-sitter-ruby#97fd3060b1bb74dd8761fc3b288efa9b2b81facc"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.1"
+source = "git+https://github.com/akshay-deepsource/tree-sitter-rust#d2b520e916658bba0ec0273f304014c88b089490"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -274,10 +302,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "winapi"
@@ -300,3 +328,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/globstar/Cargo.toml
+++ b/globstar/Cargo.toml
@@ -26,11 +26,13 @@ path = "../test-utils"
 [dependencies.marvin]
 path = "../marvin"
 
-[dev-dependencies.tree-sitter-yaml]
-git = "https://github.com/akshay-deepsource/tree-sitter-yaml"
- 
-[dev-dependencies.tree-sitter-bash]
-git = "https://github.com/akshay-deepsource/tree-sitter-bash"
+[dev-dependencies]
+tree-sitter-yaml       = { git = "https://github.com/akshay-deepsource/tree-sitter-yaml" }
+tree-sitter-bash       = { git = "https://github.com/akshay-deepsource/tree-sitter-bash" }
+tree-sitter-rust       = { git = "https://github.com/akshay-deepsource/tree-sitter-rust" }
+tree-sitter-elm        = { git = "https://github.com/akshay-deepsource/tree-sitter-elm" }
+tree-sitter-dockerfile = { git = "https://github.com/akshay-deepsource/tree-sitter-dockerfile" }
+once_cell              = "^1.14"
 
 [dev-dependencies.tree-sitter-ruby]
 git = "https://github.com/akshay-deepsource/tree-sitter-ruby"
@@ -39,3 +41,14 @@ git = "https://github.com/akshay-deepsource/tree-sitter-ruby"
 default = []
 testing = ["pretty_assertions"]
 
+[[example]]
+name = "simple"
+path = "examples/simple/main.rs"
+
+[[example]]
+name = "scopes"
+path = "examples/scopes/main.rs"
+
+[[example]]
+name = "injections"
+path = "examples/injections/main.rs"

--- a/globstar/examples/injections/injections.scm
+++ b/globstar/examples/injections/injections.scm
@@ -1,0 +1,2 @@
+(shell_command) @injection.content
+

--- a/globstar/examples/injections/main.rs
+++ b/globstar/examples/injections/main.rs
@@ -1,0 +1,96 @@
+//! A linter that detects usage of `cd` within a `RUN` directive in a Dockerfile,
+//! instead of the `WORKDIR` directive.
+
+use globstar::{
+    traits::{IsMatch, MapCapture},
+    tree_sitter::{Language, Node, Query, QueryCursor},
+    Context, Injection, Lint, Linter, Occurrence,
+};
+use once_cell::sync::Lazy;
+
+static DOCKER: Lazy<Language> = Lazy::new(|| tree_sitter_dockerfile::language());
+static BASH: Lazy<Language> = Lazy::new(|| tree_sitter_bash::language());
+
+fn main() {
+    // The initialization of our `Linter` is similar to the example provided in `simple/main.rs`,
+    // however, we additionally call the `injection` function with an injection query. See
+    // the `injections.scm` file for more.
+    let linter = Linter::new(*DOCKER)
+        .validator(check_run_cd)
+        .injection(Injection::new(include_str!("injections.scm"), *DOCKER, *BASH).unwrap());
+
+    if let Err(e) = linter.run_analysis() {
+        eprintln!("{e:?}");
+    }
+}
+
+const RUN_CD: Lint = Lint {
+    name: "run-cd",
+    code: "DOK-W1000",
+};
+
+fn check_run_cd<'a>(node: Node, ctx: &Option<Context<'a>>, src: &[u8]) -> Vec<Occurrence> {
+    // this query operates upon the base language (dockerfile)
+    let query = Query::new(
+        *DOCKER,
+        r#"
+        (run_instruction (shell_command) @shell)
+        "#,
+    )
+    .unwrap();
+
+    // this query operates upon the target language (bash)
+    let bash_query = Query::new(
+        *BASH,
+        r#"
+        (command name: (_) @command-name)
+        (#match? @command-name "cd")
+        "#,
+    )
+    .unwrap();
+
+    ctx.as_ref().map_or_else(Vec::new, |ctx| {
+        QueryCursor::new()
+            .matches(&query, node, src)
+            .filter_map_capture("shell", |capture| {
+                // Context::injected_tree_of fetches an injected syntaxe tree, if any, at the
+                // position of a given node
+                ctx.injected_tree_of(&capture.node)
+                    .and_then(|injected_tree| {
+                        let original_range = injected_tree.original_range;
+                        // run any additional processing upon the root node of the injected syntax
+                        // tree, in this case, another tree-sitter query
+                        let root_node = injected_tree.tree.root_node();
+                        QueryCursor::new()
+                            .is_match(&bash_query, root_node, src) // see `globstar::traits::IsMatch`
+                            .then(|| {
+                                let at = original_range;
+                                let message = "Use `WORKDIR` directive instead of `RUN cd`";
+                                RUN_CD.raise(at, message)
+                            })
+                    })
+            })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linter() -> Linter {
+        Linter::new(*DOCKER)
+            .validator(check_run_cd)
+            .injection(Injection::new(include_str!("injections.scm"), *DOCKER, *BASH).unwrap())
+            .comment_str("#")
+    }
+
+    #[test]
+    fn smoke_test() {
+        linter().test(
+            r#"
+            RUN cd ..
+              # ^^^^^ Use `WORKDIR` directive instead of `RUN cd`
+            "#,
+        )
+    }
+}

--- a/globstar/examples/readme.md
+++ b/globstar/examples/readme.md
@@ -1,0 +1,17 @@
+The `examples` directory contains the following example
+analyzers, in increasing order of complexity:
+
+- `simple`: a basic `globstar` analyzer targeting Rust
+- `scopes`: an example that covers scope-resolution and
+  scoping queries
+- `injections`: an example that covers language injections
+  using multiple tree-sitter grammars
+
+To run the tests for any example:
+
+```shell
+# cargo test --features testing --example <example-name>
+$ cargo test --features testing --example simple
+
+# see /globstar/Cargo.toml for a full list of examples
+```

--- a/globstar/examples/scopes/main.rs
+++ b/globstar/examples/scopes/main.rs
@@ -1,0 +1,111 @@
+//! A linter that detects variable shadowing in Elm.
+
+use globstar::{
+    traits::MapCapture,
+    tree_sitter::{Language, Node, Query, QueryCursor, Range},
+    Context, Lint, Linter, Occurrence,
+};
+use once_cell::sync::Lazy;
+
+static ELM: Lazy<Language> = Lazy::new(|| tree_sitter_elm::language());
+
+fn main() {
+    // The initialization of our `Linter` is similar to the example provided in `simple/main.rs`,
+    // however, we additionally call the `scopes` function with a scope resolution query. See
+    // the `scopes.scm` file for more.
+    let linter = Linter::new(*ELM)
+        .validator(check_variable_shadowing)
+        .scopes(include_str!("scopes.scm"));
+
+    if let Err(e) = linter.run_analysis() {
+        eprintln!("{e:?}");
+    }
+}
+
+const VARIABLE_SHADOWING: Lint = Lint {
+    name: "variable-shadowing",
+    code: "ELM-W1000",
+};
+
+// The idea behind this rule is to look for every definition, and check if any parent
+// scope contains a definition by the same name.
+fn check_variable_shadowing<'a>(
+    node: Node,
+    ctx: &Option<Context<'a>>,
+    src: &[u8],
+) -> Vec<Occurrence> {
+    let query = Query::new(
+        *ELM,
+        r#"
+        (function_declaration_left (lower_case_identifier)) @def
+        "#,
+    )
+    .unwrap();
+
+    // Context contains a fully resolved scope tree, created based on the scope query
+    ctx.as_ref().map_or_else(Vec::new, |ctx| {
+        QueryCursor::new()
+            .matches(&query, node, |_n: Node| std::iter::empty())
+            .filter_map_capture("def", |capture| {
+                let at = capture.node.range();
+                let text = capture.node.utf8_text(src).unwrap();
+
+                // `scope_stack_of` produces a stack of scopes, with the current (most deeply
+                // nested scope) at the top, and the root (least deeply nested scope) at the bottom
+                // of the stack.
+                let scope_stack = ctx.scope_stack_of(capture.node).unwrap();
+                let mut shadowed_range: Option<Range> = None;
+
+                // check to see if the captured def shadows any pre-existing definition
+                // `skip(1)` skips the current scope, and begins the search from the parent
+                // scope.
+                for scope in scope_stack.skip(1) {
+                    for local_def in scope.borrow().local_defs.iter() {
+                        if local_def.borrow().name == text {
+                            shadowed_range = Some(local_def.borrow().def_range);
+                        }
+                    }
+                }
+                if shadowed_range.is_none() {
+                    return None;
+                }
+                let (s_row, s_col) = {
+                    let s = shadowed_range.unwrap();
+                    (s.start_point.row + 1, s.start_point.column + 1)
+                };
+                let message = format!(
+                    "Shadowing `{}`, defined on line {}, col {}",
+                    text, s_row, s_col
+                );
+                Some(VARIABLE_SHADOWING.raise(at, message))
+            })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linter() -> Linter {
+        Linter::new(*ELM)
+            .validator(check_variable_shadowing)
+            .scopes(include_str!("scopes.scm"))
+            .comment_str("--")
+    }
+
+    #[test]
+    fn smoke_test() {
+        linter().test(
+            r#"
+            f = 2 + 1
+            g =
+                let
+                    a = 2
+                    f = 2
+                 -- ^ Shadowing `f`, defined on line 1, col 1
+                in
+                    t + f
+            "#,
+        )
+    }
+}

--- a/globstar/examples/scopes/scopes.scm
+++ b/globstar/examples/scopes/scopes.scm
@@ -1,0 +1,24 @@
+;;; globstar recognizes 3 types of captures to build scopes:
+;;;
+;;; - @local.scope: creates a new scope at the captured node
+;;; - @local.definition: creates a definition in the current scope
+;;; - @local.reference: creates reference to an existing definition, if any. If no definition
+;;;   exists, a dangling reference is created.
+
+;;; scopes
+(type_alias_declaration) @local.scope
+(type_declaration) @local.scope
+(type_annotation) @local.scope
+(port_annotation) @local.scope
+(infix_declaration) @local.scope
+(let_in_expr) @local.scope
+
+;;; defs
+(function_declaration_left (lower_pattern (lower_case_identifier)) @local.definition)
+(function_declaration_left (lower_case_identifier) @local.definition)
+
+;;; refs
+(value_expr(value_qid(upper_case_identifier)) @local.reference)
+(value_expr(value_qid(lower_case_identifier)) @local.reference)
+(type_ref (upper_case_qid) @local.reference)
+

--- a/globstar/examples/simple/main.rs
+++ b/globstar/examples/simple/main.rs
@@ -1,0 +1,114 @@
+//! A linter that detects the usage of certain function names in
+//! Rust code and flags them.
+
+use globstar::{
+    traits::MapCapture,
+    tree_sitter::{Language, Node, Query, QueryCursor},
+    Context, Lint, Linter, Occurrence,
+};
+
+use once_cell::sync::Lazy;
+
+static RUST: Lazy<Language> = Lazy::new(|| tree_sitter_rust::language());
+
+fn main() {
+    // initalize a linter for the rust language
+    let linter = Linter::new(*RUST)
+        .extension("rs")
+        .ignore(r#"Cargo\.toml"#)
+        .validator(check_disallowed_method_names);
+
+    if let Err(e) = linter.run_analysis() {
+        eprintln!("{e:?}");
+    }
+}
+
+// A list of names to be disallowed in Rust code
+const DISALLOWED_NAMES: &[&str] = &[
+    // avoid placeholder names
+    "foo",
+    "bar",
+    // avoid methods that can cause UB
+    "str::from_utf8_unchecked",
+];
+
+// Declare a lint to raise
+const DISALLOWED_NAMES_RULE: Lint = Lint {
+    name: "disallowed-names",
+    code: "RS-W1000",
+};
+
+// This is our validator function, see `globstar::ValidatorFn` for more. Each "rule" is expressed
+// as a `ValidatorFn`. globstar provides a few traits (see `globstar::traits`) to help with the
+// construction of a `ValidatorFn`.
+//
+// `node`: This refers to the `root_node` of every file that is successfully parsed.
+// `_ctx`: This contains information about scopes and injections, if available
+//   (see other examples for more)
+// `src`: Contains the source for the entire file as bytes. This may be passed into
+// QueryCursor::matches, if your query contains captures.
+fn check_disallowed_method_names<'a>(
+    node: Node,
+    _ctx: &Option<Context<'a>>,
+    src: &[u8],
+) -> Vec<Occurrence> {
+    // The easiest way to detect an antipattern in source-code is to use a tree-sitter query.
+    // This query looks for all function call expressions, and captures the name of the
+    // function in the `@function-name` capture.
+    let query = Query::new(*RUST, "(call_expression function: (_) @function-name)").unwrap();
+
+    QueryCursor::new()
+        .matches(&query, node, src)
+        // globstar provides a helper function `filter_map_capture` in the `MapCapture` trait,
+        // that applies a closure to every capture by name. In this case, we are raising
+        // the DISALLOWED_NAMES_RULE lint upon every capture called `function-name`.
+        .filter_map_capture("function-name", |capture| {
+            let text = capture.node.utf8_text(src).unwrap();
+            let location = capture.node.range();
+            DISALLOWED_NAMES.contains(&text).then(|| {
+                let message = format!("Use of disallowed method: `{}`", text);
+                // Use Lint::raise to produce an `Occurrence`
+                DISALLOWED_NAMES_RULE.raise(location, message)
+            })
+        })
+}
+
+// globstar provides a few helpers for fixture-based testing. These are hidden away
+// behind the `testing` feature. Use `cargo test --features testing` to make use of
+// globstar's test utilites.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // For each test, we setup a linter, not too different from the one used in our `main`
+    // function:
+    fn setup_linter() -> Linter {
+        Linter::new(*RUST)
+            .comment_str("//")
+            .validator(check_disallowed_method_names)
+    }
+
+    #[test]
+    fn smoke_test() {
+        let linter = setup_linter();
+
+        // To test the lint, call Linter::test, by passing annotated source code as the argument.
+        // It is a good practice to put the source code in a raw string. Locations that are
+        // expected to be annotated, have to be followed by an "annotation" comment. These comments
+        // are single line comments, with the "caret" character to denote the span of the
+        // occurrence, and the message provided by the occurrence:
+        linter.test(
+            r#"
+            fn main() {
+                let a = foo();
+                     // ^^^ Use of disallowed method: `foo`
+
+                unsafe {
+                    let b = str::from_utf8_unchecked("bar");
+                         // ^^^^^^^^^^^^^^^^^^^^^^^^ Use of disallowed method: `str::from_utf8_unchecked`
+                }
+            }
+            "#,
+        )
+    }
+}


### PR DESCRIPTION
fixes LAE-5480, copying `/globstar/examples/readme.md`:

---

The `examples` directory contains the following example
analyzers, in increasing order of complexity:

- `simple`: a basic `globstar` analyzer targeting Rust
- `scopes`: an example that covers scope-resolution and
  scoping queries
- `injections`: an example that covers language injections
  using multiple tree-sitter grammars

To run the tests for any example:

```shell
# cargo test --features testing --example <example-name>
$ cargo test --features testing --example simple

# see /globstar/Cargo.toml for a full list of examples
```
